### PR TITLE
[fix] type errors

### DIFF
--- a/src/models/podcast_station.ts
+++ b/src/models/podcast_station.ts
@@ -13,7 +13,8 @@ export default class PodcastStationManager extends BaseModel {
     console.log('aa');
     let returnArray = [];
     try {
-      const jsonData = JSON.parse(this.store.get('podcastList'));
+      const jsonString = this.store.get('podcastList') as string;
+      const jsonData = JSON.parse(jsonString);
 
       console.log(jsonData);
       for (const idx in jsonData) {


### PR DESCRIPTION
> Type 'unknown' is not assignable to type 'string'.

declareを定義する方が本質的だが、electron-storeの使い方問題の可能性もあるため`as string`で抑制する程度にとどめた